### PR TITLE
Refactor/player

### DIFF
--- a/src/entity/act/hereditary.rs
+++ b/src/entity/act/hereditary.rs
@@ -350,7 +350,8 @@ impl Action for InjectRnaVirus {
         owner: &mut Object,
     ) -> ActionResult {
         let target_pos: Position = owner.pos.get_translated(&self.target.to_pos());
-        if let Some((index, Some(mut target))) = objects.extract_with_idx(&target_pos) {
+        // TODO: extract with index is non-deterministic, extract by something else
+        if let Some((index, Some(mut target))) = objects.extract_blocking_with_idx(&target_pos) {
             // check whether the virus can attach to the object and whether the object is an actual
             // cell and not a plasmid or another virus
             // if yes, replace the control and force the cell to produce viruses

--- a/src/game/consts.rs
+++ b/src/game/consts.rs
@@ -18,4 +18,4 @@ pub const PAR_CON_Z: usize = 20000;
 
 pub const MENU_WIDTH: i32 = 20;
 
-pub const PLAYER: usize = 0; // player object reference, index of the object vector
+pub const PLAYER: usize = (WORLD_WIDTH * WORLD_HEIGHT) as usize; // player object reference, index of the object vector

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -517,7 +517,6 @@ impl rltk::GameState for Game {
         }
 
         // The particles need to be queried each cycle to activate and cull them in time.
-        // TODO: move particle render routine into separate function
         particles().render(ctx);
         self.re_render = particles().update(ctx);
 

--- a/src/game/objects.rs
+++ b/src/game/objects.rs
@@ -41,20 +41,18 @@ impl ObjectStore {
     }
 
     pub fn get_tile_at(&mut self, x: i32, y: i32) -> &mut Option<Object> {
-        // offset by one because player is the first object
-        &mut self.objects[(y as usize * (game::consts::WORLD_WIDTH as usize) + x as usize) + 1]
+        let idx = coord_to_idx(game::consts::WORLD_WIDTH, x, y);
+        &mut self.objects[idx]
     }
 
-    /// Allocate enough space in the object vector to fit the player and all world tiles.
+    /// Allocate enough space in the object vector to fit all world tiles and some room to spare.
     pub fn blank_world(&mut self) {
         self.objects.clear();
-        self.objects.resize_with(self.world_tile_count + 1, || None);
+        self.objects.resize_with(self.world_tile_count * 2, || None);
         for y in 0..game::consts::WORLD_HEIGHT {
             for x in 0..game::consts::WORLD_WIDTH {
-                // debug!("placing tile at ({}, {})", x, y);
-                self.objects
-                    [((y as usize) * (game::consts::WORLD_WIDTH as usize) + (x as usize)) + 1]
-                    .replace(world_gen::Tile::wall(x, y, false));
+                let idx = coord_to_idx(game::consts::WORLD_WIDTH, x, y);
+                self.objects[idx].replace(world_gen::Tile::wall(x, y, false));
             }
         }
     }
@@ -66,10 +64,8 @@ impl ObjectStore {
     ) {
         for y in 0..game::consts::WORLD_HEIGHT {
             for x in 0..game::consts::WORLD_WIDTH {
-                // debug!("setting tile dna at ({}, {})", x, y);
-                if let Some(tile) = &mut self.objects
-                    [((y as usize) * (game::consts::WORLD_WIDTH as usize) + (x as usize)) + 1]
-                {
+                let idx = coord_to_idx(game::consts::WORLD_WIDTH, x, y);
+                if let Some(tile) = &mut self.objects[idx] {
                     let (sensors, processors, actuators, dna) = gene_library.new_genetics(
                         rng,
                         genetics::DnaType::Nucleus,
@@ -90,9 +86,8 @@ impl ObjectStore {
     ) {
         for y in 0..game::consts::WORLD_HEIGHT {
             for x in 0..game::consts::WORLD_WIDTH {
-                if let Some(tile) = &mut self.objects
-                    [((y as usize) * (game::consts::WORLD_WIDTH as usize) + (x as usize)) + 1]
-                {
+                let idx = coord_to_idx(game::consts::WORLD_WIDTH, x, y);
+                if let Some(tile) = &mut self.objects[idx] {
                     let (sensors, processors, actuators, dna) = gene_library.dna_to_traits(
                         genetics::DnaType::Nucleus,
                         &gene_library.dna_from_trait_strs(rng, &traits),
@@ -100,10 +95,6 @@ impl ObjectStore {
                     tile.set_genome(sensors, processors, actuators, dna);
                     tile.processors.life_elapsed =
                         rng.gen_range(0..tile.processors.life_expectancy);
-                    // println!(
-                    //     "TILE AGE: {}/{}",
-                    //     tile.processors.life_elapsed, tile.processors.life_expectancy
-                    // );
                 }
             }
         }
@@ -119,6 +110,8 @@ impl ObjectStore {
             }
             None => {
                 trace!("setting player object {:?}", object);
+                let idx = coord_to_idx(game::consts::WORLD_WIDTH, object.pos.x(), object.pos.y());
+                self.occupation[idx] += 1;
                 self.objects[game::consts::PLAYER].replace(object);
             }
         }
@@ -142,12 +135,13 @@ impl ObjectStore {
         }
     }
 
-    pub fn extract_with_idx(&mut self, pos: &Position) -> Option<(usize, Option<Object>)> {
-        let idx = position_to_index(pos.x(), pos.y());
-        if idx < self.objects.len() {
+    /// Extract and object with the given position and return both the object and index of it.
+    pub fn extract_blocking_with_idx(&mut self, pos: &Position) -> Option<(usize, Option<Object>)> {
+        let idx = coord_to_idx(game::consts::WORLD_WIDTH, pos.x(), pos.y());
+        if self.occupation[idx] == 0 {
             Some((idx, self.extract_by_index(idx)))
         } else {
-            None
+            self.extract_non_tile_by_pos(pos)
         }
     }
 
@@ -203,18 +197,16 @@ impl ObjectStore {
         match item {
             Some(obj) => {
                 // debug!("replace object {} @ index {}", object.visual.name, index);
-                let is_moved = object.pos.update();
+                let last_xy = object.pos.update();
                 // record position changes of non-tiles for efficient occupation queries
-                if is_moved && object.tile.is_none() {
-                    let last_idx = coord_to_idx(
-                        game::consts::WORLD_WIDTH,
-                        object.pos.last_x(),
-                        object.pos.last_y(),
-                    );
-                    self.occupation[last_idx] -= 1;
-                    let this_idx =
-                        coord_to_idx(game::consts::WORLD_WIDTH, object.pos.x(), object.pos.y());
-                    self.occupation[this_idx] += 1;
+                if object.tile.is_none() {
+                    if let Some((last_x, last_y)) = last_xy {
+                        let last_idx = coord_to_idx(game::consts::WORLD_WIDTH, last_x, last_y);
+                        let this_idx =
+                            coord_to_idx(game::consts::WORLD_WIDTH, object.pos.x(), object.pos.y());
+                        self.occupation[last_idx] -= 1;
+                        self.occupation[this_idx] += 1;
+                    }
                 }
                 obj.replace(object);
             }
@@ -229,7 +221,7 @@ impl ObjectStore {
 
     /// Check whether there is an object, tile or not, blocking access to the given world coordinate
     pub fn is_pos_blocked(&self, p: &Position) -> bool {
-        let tile_idx = position_to_index(p.x(), p.y());
+        let tile_idx = coord_to_idx(game::consts::WORLD_WIDTH, p.x(), p.y());
         let is_blocking_tile = if let Some(obj) = &self.objects[tile_idx] {
             obj.physics.is_blocking
         } else {
@@ -266,8 +258,7 @@ impl ObjectStore {
 
     /// Return a Vec slice with all tiles in the world.
     pub fn get_tiles(&self) -> &[Option<Object>] {
-        let start: usize = 1;
-        &self.objects[start..self.world_tile_count]
+        &self.objects[..self.world_tile_count]
     }
 
     pub fn get_neighborhood_tiles(&self, pos: Position) -> Neighborhood {
@@ -276,8 +267,7 @@ impl ObjectStore {
 
     /// Return a Vec slice with all tiles in the world.
     pub fn get_tiles_mut(&mut self) -> &mut [Option<Object>] {
-        let start: usize = 1;
-        &mut self.objects[start..self.world_tile_count]
+        &mut self.objects[..self.world_tile_count]
     }
 
     /// Return a Vec slice with all objects that are not tiles in the world.
@@ -332,15 +322,13 @@ impl rltk::BaseMap for ObjectStore {
 impl rltk::Algorithm2D for ObjectStore {
     /// Convert a Point (x/y) to an array index.
     fn point2d_to_index(&self, pt: rltk::Point) -> usize {
-        (pt.y as usize * (game::consts::WORLD_WIDTH as usize) + pt.x as usize) + (1 as usize)
+        coord_to_idx(game::consts::WORLD_WIDTH, pt.x, pt.y)
     }
 
     /// Convert an array index to a point. Defaults to an index based on an array
     fn index_to_point2d(&self, idx: usize) -> rltk::Point {
-        rltk::Point::new(
-            (idx - 1) as i32 % game::consts::WORLD_WIDTH,
-            (idx - 1) as i32 / game::consts::WORLD_WIDTH,
-        )
+        let coord = _idx_to_coord(game::consts::WORLD_WIDTH as usize, idx);
+        rltk::Point::from_tuple(coord)
     }
 
     fn dimensions(&self) -> rltk::Point {
@@ -389,24 +377,12 @@ impl<'a> Iterator for Neighborhood<'a> {
                     && y >= 0
                     && y < game::consts::WORLD_HEIGHT
                 {
-                    return Some(&self.buffer[position_to_index(x, y)]);
+                    return Some(&self.buffer[coord_to_idx(game::consts::WORLD_WIDTH, x, y)]);
                 }
             }
             None
         }
     }
-}
-
-/// Convert a Point (x/y) to an index in the object storage.
-fn position_to_index(x: i32, y: i32) -> usize {
-    (y as usize * (game::consts::WORLD_WIDTH as usize) + x as usize) + (1 as usize)
-}
-
-/// Convert an object storage index to a point.
-fn _index_to_position(idx: usize) -> Position {
-    let x = (idx - 1) as i32 % game::consts::WORLD_WIDTH;
-    let y = (idx - 1) as i32 / game::consts::WORLD_WIDTH;
-    Position::from_xy(x, y)
 }
 
 // Convert coordinate to an index in a vector.

--- a/src/game/position.rs
+++ b/src/game/position.rs
@@ -63,14 +63,6 @@ impl Position {
         self.y
     }
 
-    pub fn last_x(&self) -> i32 {
-        self.last_x
-    }
-
-    pub fn last_y(&self) -> i32 {
-        self.last_y
-    }
-
     pub fn is_equal(&self, other: &Position) -> bool {
         self.x == other.x && self.y == other.y
     }
@@ -99,15 +91,22 @@ impl Position {
         self.y = p.y;
     }
 
-    /// Return `true` if the position has changed since the last update, `false` otherwise.
+    /// Return previous position if the it has changed since the last update, `None` otherwise.
     /// To be used by the `crate::game::ObjectStore`
-    pub fn update(&mut self) -> bool {
+    pub fn update(&mut self) -> Option<(i32, i32)> {
         let is_changed = self.x != self.last_x || self.y != self.last_y;
+        let result = if is_changed {
+            Some((self.last_x, self.last_y))
+        } else {
+            None
+        };
+
         if is_changed {
             self.last_x = self.x;
             self.last_y = self.y;
         }
-        is_changed
+
+        result
     }
 
     pub fn is_adjacent(&self, other: &Position) -> bool {

--- a/src/game/state.rs
+++ b/src/game/state.rs
@@ -110,12 +110,11 @@ impl State {
             // return the result of our action
             process_result
         } else {
-            // panic!("no object at index {}", self.obj_idx);
-            // objects.get_vector_mut().remove(self.obj_idx);
+            trace!("no object at index {}, skipping its turn", self.obj_idx);
 
             // increase object index and turn counter
             self.conclude_advance_turn(objects.get_obj_count());
-            act::ObjectFeedback::Render
+            act::ObjectFeedback::NoFeedback
         }
     }
 
@@ -309,8 +308,7 @@ impl State {
                 debug!("{} died!", actor.visual.name);
             }
 
-            // if the dead object is a player then keep it in the world,
-            // otherwise remove it.
+            // If the dead object is a player then keep it in the world, otherwise remove it.
             // NOTE: Maybe keep dead material around for scavenging.
             if actor.is_player() {
                 objects[self.obj_idx].replace(actor);

--- a/src/world_gen/mod.rs
+++ b/src/world_gen/mod.rs
@@ -57,8 +57,3 @@ impl Tile {
             .control(control::Controller::Npc(Box::new(ai::AiTile)))
     }
 }
-
-/// For use in lambdas.
-pub fn is_explored(tile: &Tile) -> Option<&bool> {
-    Some(&tile.is_explored)
-}


### PR DESCRIPTION
Move the player id from the front of the objects vector to behind the tiles for more consistent non-tile processing